### PR TITLE
fix broken link in introduction to lexicography doc

### DIFF
--- a/Language Explorer/Training/Lexicography Introduction/Introduction to Lexicography.htm
+++ b/Language Explorer/Training/Lexicography Introduction/Introduction to Lexicography.htm
@@ -4515,7 +4515,7 @@
 		 corresponds to the <span style="color:#000099; font-weight:bold; ">Semantic Domains</span> field in the lexicon. The list of semantic domains is also used in the <span style="color:#000099; font-weight:bold; ">Collect Words</span> area and the <span style="color:#000099; font-weight:bold; ">Classified Dictionary</span> area.
 	  </p>
 	  <p>Language Explorer is distributed with a list of domains already installed. This list is the Dictionary Development Process
-		 (DDP) list of domains. You can find out more about using semantic domains by visiting the DDP website (http://www.sil.org/computing/ddp/index.htm).
+		 (DDP) list of domains, also known as the Rapid Word Collection (RWC) method. You can find out more about using semantic domains by visiting https://rapidwords.net/ and https://semdom.org/.
 		 You can edit the list to make it more relevant to your language and culture.
 	  </p>
 	  <h3 style=""><a name="sSenseStatus"></a>5.5.17&nbsp;Sense Status

--- a/Language Explorer/Training/Lexicography Introduction/Introduction to Lexicography.htm
+++ b/Language Explorer/Training/Lexicography Introduction/Introduction to Lexicography.htm
@@ -9,7 +9,7 @@
    </head>
    <body>
 	  <center><b><big><big><big>Introduction to Lexicography<br>for FieldWorks Language Explorer</big></big></big></b></center>
-	  <center><i>Ronald Moe, with revisions by others</i></center><br><center><small>November 11, 2014, revised 11 October 2016</small></center>
+	  <center><i>Ronald Moe, with revisions by others</i></center><br><center><small>November 11, 2014, revised August 20, 2025</small></center>
 	  <hr>
 	  <div>
 		 <center><big><big><b>Contents</b></big></big></center>


### PR DESCRIPTION
Replaces a broken link in the intro to lexicography document with links to rapidwords.net and semdom.org

See discussion over at https://community.software.sil.org/t/bad-link-in-help-doc/10543